### PR TITLE
Made linux' launch script work with spaces.

### DIFF
--- a/scripts/xash3d.sh
+++ b/scripts/xash3d.sh
@@ -29,10 +29,10 @@ fi
 UNAME=$(uname)
 if [ "$UNAME" = "Darwin" ]; then
 	# prepend our lib path to DYLD_LIBRARY_PATH
-	export DYLD_LIBRARY_PATH=${GAMEROOT}:$DYLD_LIBRARY_PATH
+	export DYLD_LIBRARY_PATH="${GAMEROOT}:$DYLD_LIBRARY_PATH"
 else
 	# prepend our lib path to LD_LIBRARY_PATH
-	export LD_LIBRARY_PATH=${GAMEROOT}:$LD_LIBRARY_PATH
+	export LD_LIBRARY_PATH="${GAMEROOT}:$LD_LIBRARY_PATH"
 fi
 
 # and launch the game


### PR DESCRIPTION
${GAMEROOT}:$LD_LIBRARY_PATH and ${GAMEROOT}:$DYLD_LIBRARY_PATH were unquoted, meaning that if the path had spaces it would only output a newby-unfriendly error which
A) Only could be seen if the script was executed from a terminal
B) Wasn't easy to understand nor google-friendly